### PR TITLE
chore: organize imports

### DIFF
--- a/components/AsSeenOn.js
+++ b/components/AsSeenOn.js
@@ -1,14 +1,14 @@
-import CBC from '../elements/logos/CBC'
-import LonelyPlanet from '../elements/logos/LonelyPlanet'
-import ExploreCanada from '../elements/logos/ExploreCanada'
-import PetaPixel from '../elements/logos/PetaPixel'
-import BoredPanda from '../elements/logos/BoredPanda'
 import Abduzeedo from '../elements/logos/Abduzeedo'
-import Unsplash from '../elements/logos/Unsplash'
+import BoredPanda from '../elements/logos/BoredPanda'
 import Burst from '../elements/logos/Burst'
-import Scribe from '../elements/logos/Scribe'
-import VYSUAL from '../elements/logos/VYSUAL'
+import CBC from '../elements/logos/CBC'
+import ExploreCanada from '../elements/logos/ExploreCanada'
 import Kedge from '../elements/logos/Kedge'
+import LonelyPlanet from '../elements/logos/LonelyPlanet'
+import PetaPixel from '../elements/logos/PetaPixel'
+import Scribe from '../elements/logos/Scribe'
+import Unsplash from '../elements/logos/Unsplash'
+import VYSUAL from '../elements/logos/VYSUAL'
 
 export default function AsSeenOn() {
   return (

--- a/components/CardGallery.js
+++ b/components/CardGallery.js
@@ -1,5 +1,5 @@
-import NextLink from 'next/link'
 import Image from 'next/image'
+import NextLink from 'next/link'
 
 const CardGallery = (props) => {
   return (

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,18 +1,14 @@
-import { useState } from 'react'
-import { Transition, Menu } from '@headlessui/react'
-import NextLink from 'next/link'
-import React from 'react'
-import Unsplash from '../elements/icons/Unsplash'
-import { ExternalLinkIcon, ChevronDownIcon } from '@heroicons/react/solid'
+import { Menu, Transition } from '@headlessui/react'
 import {
-  CameraIcon,
-  RssIcon,
+  CameraIcon, InboxInIcon,
+  MenuIcon, RssIcon,
   UserCircleIcon,
-  UserGroupIcon,
-  InboxInIcon,
-  MenuIcon,
-  XIcon,
+  UserGroupIcon, XIcon
 } from '@heroicons/react/outline'
+import { ChevronDownIcon, ExternalLinkIcon } from '@heroicons/react/solid'
+import NextLink from 'next/link'
+import React, { useState } from 'react'
+import Unsplash from '../elements/icons/Unsplash'
 
 function Mlink(props) {
   let { href, children, ...rest } = props

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -1,10 +1,10 @@
-import unified from 'unified'
+import { ApolloClient, gql, InMemoryCache } from '@apollo/client'
 import parse from 'remark-parse'
 import remark2react from 'remark-react'
-import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
+import unified from 'unified'
 
-import TagLabel from '../components/TagLabel'
 import SubGallery from '../components/SubGallery'
+import TagLabel from '../components/TagLabel'
 
 import { NextSeo } from 'next-seo'
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,15 +1,13 @@
 import 'tailwindcss/tailwind.css'
 
-import React, { useEffect } from 'react'
-import Router from 'next/router'
 import Head from 'next/head'
 
 import { DefaultSeo } from 'next-seo'
 
 import SEO from '../next-seo-config'
 
-import Header from '../components/Header'
 import Footer from '../components/Footer'
+import Header from '../components/Header'
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -1,7 +1,7 @@
-import unified from 'unified'
+import { ApolloClient, gql, InMemoryCache } from '@apollo/client'
 import parse from 'remark-parse'
 import remark2react from 'remark-react'
-import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
+import unified from 'unified'
 
 import { NextSeo } from 'next-seo'
 

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,5 +1,5 @@
+import { ApolloClient, gql, InMemoryCache } from '@apollo/client'
 import { NextSeo } from 'next-seo'
-import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
 
 import BlogPostCard from '../../components/BlogPostCard'
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
+import { ApolloClient, gql, InMemoryCache } from '@apollo/client'
 import NextLink from 'next/link'
-import { ApolloClient, InMemoryCache, gql } from '@apollo/client'
 
 import CardGallery from '../components/CardGallery'
 


### PR DESCRIPTION
Leveraging VS Code "organize imports" feature